### PR TITLE
Fix user retrieval from Firebase Auth

### DIFF
--- a/src/app/table/actions.ts
+++ b/src/app/table/actions.ts
@@ -2,7 +2,7 @@
 
 import { validateDataConsistency } from '@/ai/flows/validate-data-consistency';
 import { logTaskHistory } from '@/lib/firestore';
-import { auth } from '@/lib/firebase'; // Assuming Firebase Auth is used for user info
+import { auth } from '@/lib/firebase'; // Firebase Auth instance for user info
 import type { ValidateDataConsistencyInput, ValidateDataConsistencyOutput } from '@/ai/flows/validate-data-consistency';
 
 export async function performDataValidation(input: ValidateDataConsistencyInput): Promise<ValidateDataConsistencyOutput> {
@@ -31,7 +31,7 @@ export async function performDataValidation(input: ValidateDataConsistencyInput)
 }
 
 export async function updateTask(taskId: string, updatedData: Partial<any>) { // Replace 'any' with your Task interface
-  const user = await auth().currentUser;
+  const user = auth.currentUser; // Retrieve current user from Firebase Auth
   const userId = user ? user.uid : 'anonymous'; // Get user ID
 
   // Fetch the current task data to compare for logging

--- a/src/components/table/interactive-table-client.tsx
+++ b/src/components/table/interactive-table-client.tsx
@@ -18,7 +18,7 @@ import { ScanSearch, ArrowUp, ArrowDown, Filter as FilterIcon, History as Histor
 import { useToast } from "@/hooks/use-toast";
 import { formatCurrency, calculateBusinessDays } from '@/lib/utils';
 import { useLanguage } from '@/context/language-context';
-import { useAuth } from '@/context/auth-context'; // Assuming auth context provides current user
+import { auth } from '@/lib/firebase'; // Firebase Auth for current user
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '@/lib/firebase'; // Import Firestore instance
@@ -45,7 +45,6 @@ export function InteractiveTableClient({ }: InteractiveTableClientProps) {
   const [isPending, startTransition] = useTransition();
   const { toast } = useToast();
   const { t } = useLanguage();
-  const { user: currentUser } = useAuth();
 
   const [editingCellKey, setEditingCellKey] = useState<string | null>(null);
   const [currentEditText, setCurrentEditText] = useState<string>("");
@@ -163,6 +162,7 @@ export function InteractiveTableClient({ }: InteractiveTableClientProps) {
   };
 
   const logChangeHistory = useCallback(async (taskId: string, action: 'created' | 'updated' | 'deleted', changes: TaskHistoryChangeDetail[] = []) => {
+    const user = auth.currentUser; // Fetch user inside the callback
     if (!taskId) {
       console.error("Cannot log history without a task ID.");
       return;
@@ -170,8 +170,8 @@ export function InteractiveTableClient({ }: InteractiveTableClientProps) {
     try {
       await logTaskHistory(
         taskId,
-        currentUser?.uid || 'system_change',
-        currentUser?.name || currentUser?.email || 'System Change',
+        user?.uid || 'system_change',
+        user?.name || user?.email || 'System Change',
         action,
         changes
       );
@@ -183,7 +183,7 @@ export function InteractiveTableClient({ }: InteractiveTableClientProps) {
         variant: "destructive",
       });
     }
-  }, [currentUser, t]);
+  }, [t]);
 
 
   const handleValidateData = () => {


### PR DESCRIPTION
## Summary
- use Firebase Auth to fetch the current user in table actions
- switch InteractiveTableClient to pull the user from Firebase Auth

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3a1dec083298a1e9fcae5f9daf3