### PR TITLE
Fix auth usage in server action

### DIFF
--- a/src/app/table/actions.ts
+++ b/src/app/table/actions.ts
@@ -31,7 +31,7 @@ export async function performDataValidation(input: ValidateDataConsistencyInput)
 }
 
 export async function updateTask(taskId: string, updatedData: Partial<any>) { // Replace 'any' with your Task interface
-  const user = await auth().currentUser;
+  const user = auth.currentUser;
   const userId = user ? user.uid : 'anonymous'; // Get user ID
 
   // Fetch the current task data to compare for logging


### PR DESCRIPTION
## Summary
- fix getting current user in table server action

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fa56c0c048329a6f9d8073307699e