### PR TITLE
Clean up unused task loader

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -271,26 +271,17 @@ export default function DashboardPage() {
 
   useEffect(() => {
     console.log("Dashboard: Recalculating metrics based on updated tasks data.");
-     const { chartData: overallProgress, teamAveragePercent, allAdmins } = calculateOverallAdminProgress(allTasks);
-      setOverallAdminProgressData(overallProgress);
-      setTeamAverageProgress(teamAveragePercent);
-    const handleTasksUpdatedEvent = () => {
-      console.log("Dashboard: Detected 'tasksUpdatedInStorage' event. Reloading data.");
-      loadAndProcessTasks();
-    };
+    const { chartData: overallProgress, teamAveragePercent, allAdmins } =
+      calculateOverallAdminProgress(allTasks);
+    setOverallAdminProgressData(overallProgress);
+    setTeamAverageProgress(teamAveragePercent);
+    setAdminsForProgressChart(allAdmins);
 
-    window.addEventListener('storage', handleStorageChange);
-    window.addEventListener('tasksUpdatedInStorage', handleTasksUpdatedEvent);
-
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-      window.removeEventListener('tasksUpdatedInStorage', handleTasksUpdatedEvent);
-    };
-      setAdminsForProgressChart(allAdmins);
-
-      const { adminAverages, teamAverage } = calculateAverageResolutionTimeByAdmin(allTasks);
-      setAverageResolutionTimeData(adminAverages);
-      setTeamAverageResolutionTime(teamAverage);
+    const { adminAverages, teamAverage } =
+      calculateAverageResolutionTimeByAdmin(allTasks);
+    setAverageResolutionTimeData(adminAverages);
+    setTeamAverageResolutionTime(teamAverage);
+  }, [allTasks]);
 
 
   const recentActivities = [


### PR DESCRIPTION
## Summary
- remove unused `loadAndProcessTasks` call and event listeners
- recompute dashboard metrics directly from `allTasks`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa56ebce4832990c067f914aa922e